### PR TITLE
카드 데이터 리스트 추가, repository 사용

### DIFF
--- a/MiniSuperApp.xcodeproj/project.pbxproj
+++ b/MiniSuperApp.xcodeproj/project.pbxproj
@@ -44,6 +44,10 @@
 		F5EAA232270B3A8F00EF2B70 /* UIView+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EAA231270B3A8F00EF2B70 /* UIView+Utils.swift */; };
 		F5EAA234270B3A9A00EF2B70 /* UIColor+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EAA233270B3A9A00EF2B70 /* UIColor+Utils.swift */; };
 		F5EAA236270B3AA600EF2B70 /* UIColor+Super.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EAA235270B3AA600EF2B70 /* UIColor+Super.swift */; };
+		F935DECD27B776E50055EC55 /* PaymentMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F935DECC27B776E50055EC55 /* PaymentMethodView.swift */; };
+		F935DECF27B77B640055EC55 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = F935DECE27B77B640055EC55 /* PaymentMethod.swift */; };
+		F935DED227B77BF90055EC55 /* CardOnFileRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F935DED127B77BF90055EC55 /* CardOnFileRepository.swift */; };
+		F935DED427B7A9EC0055EC55 /* PaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F935DED327B7A9EC0055EC55 /* PaymentMethodViewModel.swift */; };
 		F93CCF8427AF542200F16B96 /* SuperPayDashboardRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93CCF8027AF542200F16B96 /* SuperPayDashboardRouter.swift */; };
 		F93CCF8527AF542200F16B96 /* SuperPayDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93CCF8127AF542200F16B96 /* SuperPayDashboardViewController.swift */; };
 		F93CCF8627AF542200F16B96 /* SuperPayDashboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93CCF8227AF542200F16B96 /* SuperPayDashboardBuilder.swift */; };
@@ -97,6 +101,10 @@
 		F5EAA231270B3A8F00EF2B70 /* UIView+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Utils.swift"; sourceTree = "<group>"; };
 		F5EAA233270B3A9A00EF2B70 /* UIColor+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Utils.swift"; sourceTree = "<group>"; };
 		F5EAA235270B3AA600EF2B70 /* UIColor+Super.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Super.swift"; sourceTree = "<group>"; };
+		F935DECC27B776E50055EC55 /* PaymentMethodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodView.swift; sourceTree = "<group>"; };
+		F935DECE27B77B640055EC55 /* PaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethod.swift; sourceTree = "<group>"; };
+		F935DED127B77BF90055EC55 /* CardOnFileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardOnFileRepository.swift; sourceTree = "<group>"; };
+		F935DED327B7A9EC0055EC55 /* PaymentMethodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodViewModel.swift; sourceTree = "<group>"; };
 		F93CCF8027AF542200F16B96 /* SuperPayDashboardRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperPayDashboardRouter.swift; sourceTree = "<group>"; };
 		F93CCF8127AF542200F16B96 /* SuperPayDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperPayDashboardViewController.swift; sourceTree = "<group>"; };
 		F93CCF8227AF542200F16B96 /* SuperPayDashboardBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperPayDashboardBuilder.swift; sourceTree = "<group>"; };
@@ -139,6 +147,7 @@
 		F57F6ADA26DB49EA00C0117D /* FinanceHome */ = {
 			isa = PBXGroup;
 			children = (
+				F935DED027B77BCF0055EC55 /* Repository */,
 				F93CCF9727AFBB7400F16B96 /* CardOnFileDashboard */,
 				F93CCF7F27AF53C200F16B96 /* SuperPayDashboard */,
 				F57F6AE426DB4A2700C0117D /* FinanceHomeRouter.swift */,
@@ -258,6 +267,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		F935DED027B77BCF0055EC55 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				F935DED127B77BF90055EC55 /* CardOnFileRepository.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
 		F93CCF7F27AF53C200F16B96 /* SuperPayDashboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -278,6 +295,8 @@
 				F93CCF9027AFBB6600F16B96 /* CardOnFileDashboardViewController.swift */,
 				F93CCF9127AFBB6600F16B96 /* CardOnFileDashboardBuilder.swift */,
 				F93CCF9227AFBB6600F16B96 /* CardOnFileDashboardInteractor.swift */,
+				F935DECE27B77B640055EC55 /* PaymentMethod.swift */,
+				F935DED327B7A9EC0055EC55 /* PaymentMethodViewModel.swift */,
 			);
 			path = CardOnFileDashboard;
 			sourceTree = "<group>";
@@ -286,6 +305,7 @@
 			isa = PBXGroup;
 			children = (
 				F93CCF9927B3D0B800F16B96 /* AppPaymentMethodButton.swift */,
+				F935DECC27B776E50055EC55 /* PaymentMethodView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -375,9 +395,11 @@
 				F5EAA22E270B3A4500EF2B70 /* SuperPayView.swift in Sources */,
 				F5EAA220270B39DC00EF2B70 /* PushModalPresentationController.swift in Sources */,
 				F57F6AF126DB4A2D00C0117D /* ProfileHomeViewController.swift in Sources */,
+				F935DECD27B776E50055EC55 /* PaymentMethodView.swift in Sources */,
 				F93CCF9427AFBB6600F16B96 /* CardOnFileDashboardViewController.swift in Sources */,
 				F57F6AF326DB4A2D00C0117D /* ProfileHomeInteractor.swift in Sources */,
 				F5829F7626DB34AA00BFA8CD /* AppRootBuilder.swift in Sources */,
+				F935DED227B77BF90055EC55 /* CardOnFileRepository.swift in Sources */,
 				F5EAA230270B3A7100EF2B70 /* RIBs+Utils.swift in Sources */,
 				F57EBE542738468700FE9319 /* UIImage+Utils.swift in Sources */,
 				F5EAA22B270B3A4500EF2B70 /* TransportHomeBuilder.swift in Sources */,
@@ -390,6 +412,7 @@
 				F5EAA22D270B3A4500EF2B70 /* RideTypeView.swift in Sources */,
 				F93CCF9327AFBB6600F16B96 /* CardOnFileDashboardRouter.swift in Sources */,
 				F93CCF8727AF542200F16B96 /* SuperPayDashboardInteractor.swift in Sources */,
+				F935DECF27B77B640055EC55 /* PaymentMethod.swift in Sources */,
 				F93CCF9A27B3D0B800F16B96 /* AppPaymentMethodButton.swift in Sources */,
 				F93CCF8E27AFB61400F16B96 /* Formatter.swift in Sources */,
 				F5EAA219270B395900EF2B70 /* HomeWidgetView.swift in Sources */,
@@ -403,6 +426,7 @@
 				F57F6AE926DB4A2700C0117D /* FinanceHomeViewController.swift in Sources */,
 				F5829F5926DB2BC400BFA8CD /* AppDelegate.swift in Sources */,
 				F5EAA21C270B395900EF2B70 /* AppHomeViewController.swift in Sources */,
+				F935DED427B7A9EC0055EC55 /* PaymentMethodViewModel.swift in Sources */,
 				F93CCF8427AF542200F16B96 /* SuperPayDashboardRouter.swift in Sources */,
 				F5EAA236270B3AA600EF2B70 /* UIColor+Super.swift in Sources */,
 				F5829F7926DB397300BFA8CD /* AppComponent.swift in Sources */,

--- a/MiniSuperApp/FinanceHome/CardOnFileDashboard/CardOnFileDashboardBuilder.swift
+++ b/MiniSuperApp/FinanceHome/CardOnFileDashboard/CardOnFileDashboardBuilder.swift
@@ -10,9 +10,13 @@ import ModernRIBs
 protocol CardOnFileDashboardDependency: Dependency {
     // TODO: Declare the set of dependencies required by this RIB, but cannot be
     // created by this RIB.
+    var cardsOnFileRepository: CardOnFileRepository { get }
 }
 
-final class CardOnFileDashboardComponent: Component<CardOnFileDashboardDependency> {
+final class CardOnFileDashboardComponent: Component<CardOnFileDashboardDependency>,
+                                          CardOnFileDashboardInteractorDependency {
+    var cardsOnFileRepository: CardOnFileRepository { dependency.cardsOnFileRepository }
+    
 
     // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
 }
@@ -32,7 +36,10 @@ final class CardOnFileDashboardBuilder: Builder<CardOnFileDashboardDependency>, 
     func build(withListener listener: CardOnFileDashboardListener) -> CardOnFileDashboardRouting {
         let component = CardOnFileDashboardComponent(dependency: dependency)
         let viewController = CardOnFileDashboardViewController()
-        let interactor = CardOnFileDashboardInteractor(presenter: viewController)
+        let interactor = CardOnFileDashboardInteractor(
+            presenter: viewController,
+            dependency: component
+        )
         interactor.listener = listener
         return CardOnFileDashboardRouter(interactor: interactor, viewController: viewController)
     }

--- a/MiniSuperApp/FinanceHome/CardOnFileDashboard/CardOnFileDashboardInteractor.swift
+++ b/MiniSuperApp/FinanceHome/CardOnFileDashboard/CardOnFileDashboardInteractor.swift
@@ -6,6 +6,7 @@
 //
 
 import ModernRIBs
+import Combine
 
 protocol CardOnFileDashboardRouting: ViewableRouting {
     // TODO: Declare methods the interactor can invoke to manage sub-tree via the router.
@@ -14,10 +15,15 @@ protocol CardOnFileDashboardRouting: ViewableRouting {
 protocol CardOnFileDashboardPresentable: Presentable {
     var listener: CardOnFileDashboardPresentableListener? { get set }
     // TODO: Declare methods the interactor can invoke the presenter to present data.
+    func update(with viewModels: [PaymentMethodViewModel])
 }
 
 protocol CardOnFileDashboardListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
+}
+
+protocol CardOnFileDashboardInteractorDependency {
+    var cardsOnFileRepository: CardOnFileRepository { get }
 }
 
 final class CardOnFileDashboardInteractor: PresentableInteractor<CardOnFileDashboardPresentable>,
@@ -26,10 +32,16 @@ final class CardOnFileDashboardInteractor: PresentableInteractor<CardOnFileDashb
 
     weak var router: CardOnFileDashboardRouting?
     weak var listener: CardOnFileDashboardListener?
-
+    
+    private let dependency: CardOnFileDashboardInteractorDependency
+    private var cancellable: Set<AnyCancellable>
+    
     // TODO: Add additional dependencies to constructor. Do not perform any logic
     // in constructor.
-    override init(presenter: CardOnFileDashboardPresentable) {
+    init(presenter: CardOnFileDashboardPresentable,
+                  dependency: CardOnFileDashboardInteractorDependency) {
+        self.dependency = dependency
+        self.cancellable = .init()
         super.init(presenter: presenter)
         presenter.listener = self
     }
@@ -37,10 +49,19 @@ final class CardOnFileDashboardInteractor: PresentableInteractor<CardOnFileDashb
     override func didBecomeActive() {
         super.didBecomeActive()
         // TODO: Implement business logic here.
+        dependency.cardsOnFileRepository.cardOnFile.sink(receiveValue: {
+            methods in
+            let viewModels = methods.prefix(5).map(PaymentMethodViewModel.init)
+            self.presenter.update(with: viewModels)
+        }).store(in: &cancellable)
     }
 
     override func willResignActive() {
         super.willResignActive()
         // TODO: Pause any business logic.
+        cancellable.forEach {
+            $0.cancel()
+        }
+        cancellable.removeAll()
     }
 }

--- a/MiniSuperApp/FinanceHome/CardOnFileDashboard/CardOnFileDashboardViewController.swift
+++ b/MiniSuperApp/FinanceHome/CardOnFileDashboard/CardOnFileDashboardViewController.swift
@@ -75,15 +75,28 @@ final class CardOnFileDashboardViewController: UIViewController,
         self.setupViews()
     }
     
+    func update(with viewModels: [PaymentMethodViewModel]) {
+        cardOnFileStackView.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
+        //[paymentmethodviewmodel] -> [paymentmethodview]
+        let views = viewModels.map(PaymentMethodView.init)
+        views.forEach {
+            $0.roundCorners()
+            cardOnFileStackView.addArrangedSubview($0)
+        }
+        cardOnFileStackView.addArrangedSubview(addMethodButton)
+        let heightConstraints = views.map { $0.heightAnchor.constraint(equalToConstant: 60) }
+        NSLayoutConstraint.activate(heightConstraints)
+    }
+    
     private func setupViews() {
         view.addSubview(headerStackView)
         view.addSubview(cardOnFileStackView)
         
         headerStackView.addArrangedSubview(titleLabel)
         headerStackView.addArrangedSubview(seeAllButton)
-        
-        cardOnFileStackView.addArrangedSubview(addMethodButton)
-        
+
         NSLayoutConstraint.activate([
             headerStackView.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
             headerStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),

--- a/MiniSuperApp/FinanceHome/CardOnFileDashboard/PaymentMethod.swift
+++ b/MiniSuperApp/FinanceHome/CardOnFileDashboard/PaymentMethod.swift
@@ -1,0 +1,18 @@
+//
+//  PaymentMethod.swift
+//  MiniSuperApp
+//
+//  Created by gitaeklee on 2022/02/12.
+//
+
+import Foundation
+
+struct PaymentMethod: Decodable {
+    let id: String
+    let name: String
+    let digits: String
+    let color: String
+    let isPrimary: Bool
+    
+    
+}

--- a/MiniSuperApp/FinanceHome/CardOnFileDashboard/PaymentMethodViewModel.swift
+++ b/MiniSuperApp/FinanceHome/CardOnFileDashboard/PaymentMethodViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  PaymentMethodViewModel.swift
+//  MiniSuperApp
+//
+//  Created by gitaeklee on 2022/02/12.
+//
+
+import UIKit
+
+struct PaymentMethodViewModel {
+    let name: String
+    let digits: String
+    let color: UIColor
+    init(_ paymentMethod: PaymentMethod) {
+        name = paymentMethod.name
+        digits = "**** \(paymentMethod.digits)"
+        color = UIColor(hex: paymentMethod.color) ?? .systemGray2
+        
+    }
+}

--- a/MiniSuperApp/FinanceHome/CardOnFileDashboard/Views/PaymentMethodView.swift
+++ b/MiniSuperApp/FinanceHome/CardOnFileDashboard/Views/PaymentMethodView.swift
@@ -1,0 +1,54 @@
+//
+//  PaymentMethodView.swift
+//  MiniSuperApp
+//
+//  Created by gitaeklee on 2022/02/12.
+//
+
+import UIKit
+
+final class PaymentMethodView: UIView {
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 18, weight: .semibold)
+        label.textColor = .white
+        label.text = "우리은행"
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 15, weight: .regular)
+        label.textColor = .white
+        label.text = "**** 9999"
+        return label
+    }()
+    
+    init(viewModel: PaymentMethodViewModel) {
+        super.init(frame: .zero)
+        setupViews()
+        nameLabel.text = viewModel.name
+        subtitleLabel.text = viewModel.digits
+        backgroundColor = viewModel.color
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupViews()
+    }
+    
+    private func setupViews() {
+        addSubview(nameLabel)
+        addSubview(subtitleLabel)
+        backgroundColor = .systemIndigo
+        NSLayoutConstraint.activate([
+            nameLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 24),
+            nameLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            
+            subtitleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24),
+            subtitleLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+    }
+}

--- a/MiniSuperApp/FinanceHome/FinanceHomeBuilder.swift
+++ b/MiniSuperApp/FinanceHome/FinanceHomeBuilder.swift
@@ -7,15 +7,19 @@ protocol FinanceHomeDependency: Dependency {
 
 final class FinanceHomeComponent: Component<FinanceHomeDependency>,
                                     SuperPayDashboardDependency,
-                                    CardOnFileDashboardDependency {
+                                  CardOnFileDashboardDependency {
+    var cardsOnFileRepository: CardOnFileRepository
+    
     var balance: ReadOnlyCurrentValuePublisher<Double>{ balancePublisher }
     private let balancePublisher: CurrentValuePublisher<Double>
     
     init(
         dependency: FinanceHomeDependency,
-        balance: CurrentValuePublisher<Double>
+        balance: CurrentValuePublisher<Double>,
+        cardOnFileRepository: CardOnFileRepository
     ) {
         self.balancePublisher = balance
+        self.cardsOnFileRepository = cardOnFileRepository
         super.init(dependency: dependency)
     }
   // TODO: Declare 'fileprivate' dependencies that are only used by this RIB.
@@ -38,7 +42,8 @@ final class FinanceHomeBuilder: Builder<FinanceHomeDependency>, FinanceHomeBuild
     
     let component = FinanceHomeComponent(
         dependency: dependency,
-        balance: balancePublisher
+        balance: balancePublisher,
+        cardOnFileRepository: CardOnFileRepositoryImp()
     )
     let viewController = FinanceHomeViewController()
     let interactor = FinanceHomeInteractor(presenter: viewController)

--- a/MiniSuperApp/FinanceHome/Repository/CardOnFileRepository.swift
+++ b/MiniSuperApp/FinanceHome/Repository/CardOnFileRepository.swift
@@ -1,0 +1,24 @@
+//
+//  CardOnFileRepository.swift
+//  MiniSuperApp
+//
+//  Created by gitaeklee on 2022/02/12.
+//
+
+import Foundation
+
+protocol CardOnFileRepository {
+    var cardOnFile: ReadOnlyCurrentValuePublisher<[PaymentMethod]> { get }
+}
+
+final class CardOnFileRepositoryImp: CardOnFileRepository {
+    var cardOnFile: ReadOnlyCurrentValuePublisher<[PaymentMethod]> { paymentMethodsSubject }
+    
+    private let paymentMethodsSubject = CurrentValuePublisher<[PaymentMethod]> ([
+        PaymentMethod(id: "0", name: "우리은행", digits: "0123", color: "#f19a38ff", isPrimary: false),
+        PaymentMethod(id: "1", name: "신한카드", digits: "0987", color: "#3478f6ff", isPrimary: false),
+        PaymentMethod(id: "2", name: "현대카드", digits: "8121", color: "#78c5f5ff", isPrimary: false),
+        PaymentMethod(id: "3", name: "국민은행", digits: "2812", color: "#65c466ff", isPrimary: false),
+        PaymentMethod(id: "4", name: "카카오뱅크", digits: "8751", color: "#ffcc00ff", isPrimary: false)
+    ])
+}


### PR DESCRIPTION
기능 추가 : 
- 슈퍼페이 탭의 카드 데이터를 리스트로 보여주는 기능 추가 

검토사항 : 
- 새로 생성된 view 모듈 
- repository 
- 카드 데이터 모델 


결과: 

![simulator_screenshot_295CF426-E15E-4BC7-9AF1-A6D09E55F8C6](https://user-images.githubusercontent.com/5070020/153704811-6a2724da-7089-47b0-9a85-a32092bd86b8.png)
